### PR TITLE
ENG-10202 Doesn't like string "1_000_000", got rid of underscores

### DIFF
--- a/src/main/java/org/voltdb/exportclient/KinesisFirehoseExportClient.java
+++ b/src/main/java/org/voltdb/exportclient/KinesisFirehoseExportClient.java
@@ -93,7 +93,7 @@ public class KinesisFirehoseExportClient extends ExportClientBase {
         m_timeZone = TimeZone.getTimeZone(config.getProperty("timezone", VoltDB.REAL_DEFAULT_TIMEZONE.getID()));
 
         config.setProperty(ROW_LENGTH_LIMIT,
-                config.getProperty(ROW_LENGTH_LIMIT,"1_000_000"));
+                config.getProperty(ROW_LENGTH_LIMIT,"1000000"));
     }
 
     @Override


### PR DESCRIPTION
inary file build/classes/main/org/voltdb/exportclient/KinesisFirehoseExportClient.class matches
demo/log/volt.log:2016-05-09 22:33:38,207   ERROR [Ad Hoc Planner - 0] HOST: Error validating deployment configuration: For input string: "1_000_000"
src/main/java/org/voltdb/exportclient/KinesisFirehoseExportClient.java:                config.getProperty(ROW_LENGTH_LIMIT,"1_000_000"));
