### PR TITLE
Disable backpressure

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,5 @@ INSERT INTO ALERTS (ID,MSG,CONTINENT,COUNTRY) VALUES (1,'fab-02 inoperable','EU'
 - `access.key` (mandatory) user's access key
 - `secret.key` (mandatory) user's secret key
 - `timezone` (optional, _default:_ local timezone) timezone used to format timestamp values
+- `stream.limit` (optional, _default:_ 5000 records/s) Firehose Delivery Stream limit on AWS side, i.e. how many records per second it can accept
+- `concurrent.writers` (optional, _default:_ 1) The number of writers in the concurrent writer pool, sharing the connection to AWS

--- a/src/main/java/org/voltdb/exportclient/BackOff.java
+++ b/src/main/java/org/voltdb/exportclient/BackOff.java
@@ -1,0 +1,58 @@
+package org.voltdb.exportclient;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+abstract class BackOff {
+    int base;
+    int cap;
+
+    public BackOff(int base, int cap) {
+        this.base = base;
+        this.cap = cap;
+    }
+
+    public int expo(int n) {
+        return Math.min(cap, base * (1<<n));
+    }
+
+    abstract public int backoff(int n);
+}
+
+class ExpoBackOffFullJitter extends BackOff {
+
+    public ExpoBackOffFullJitter(int base, int cap) {
+        super(base, cap);
+    }
+
+    @Override
+    public int backoff(int n) {
+        return ThreadLocalRandom.current().nextInt(expo(n));
+    }
+}
+
+class ExpoBackOffEqualJitter extends BackOff {
+
+    public ExpoBackOffEqualJitter(int base, int cap) {
+        super(base, cap);
+    }
+
+    @Override
+    public int backoff(int n) {
+        int v = expo(n) / 2 ;
+        return ThreadLocalRandom.current().nextInt(v, 3 * v);
+    }
+}
+
+class ExpoBackOffDecor extends BackOff {
+    int sleep;
+    public ExpoBackOffDecor(int base, int cap) {
+        super(base, cap);
+        sleep = base;
+    }
+
+    @Override
+    public int backoff(int n) {
+        sleep = Math.min(cap, ThreadLocalRandom.current().nextInt(sleep * (1+n) + base));
+        return sleep;
+    }
+}

--- a/src/main/java/org/voltdb/exportclient/BackOff.java
+++ b/src/main/java/org/voltdb/exportclient/BackOff.java
@@ -1,3 +1,27 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package org.voltdb.exportclient;
 
 import java.util.concurrent.ThreadLocalRandom;

--- a/src/main/java/org/voltdb/exportclient/BackOffFactory.java
+++ b/src/main/java/org/voltdb/exportclient/BackOffFactory.java
@@ -1,3 +1,27 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package org.voltdb.exportclient;
 
 public class BackOffFactory {

--- a/src/main/java/org/voltdb/exportclient/BackOffFactory.java
+++ b/src/main/java/org/voltdb/exportclient/BackOffFactory.java
@@ -1,0 +1,16 @@
+package org.voltdb.exportclient;
+
+public class BackOffFactory {
+    public static BackOff getBackOff(String backOffType, int backOffBase, int backOffCap) {
+        switch (backOffType) {
+        case "full":
+            return new ExpoBackOffFullJitter(backOffBase, backOffCap);
+        case "equal":
+            return new ExpoBackOffEqualJitter(backOffBase, backOffCap);
+        case "decor":
+            return new ExpoBackOffDecor(backOffBase, backOffCap);
+        default:
+            return new ExpoBackOffDecor(backOffBase, backOffCap);
+        }
+    }
+}

--- a/src/main/java/org/voltdb/exportclient/FirehoseExportException.java
+++ b/src/main/java/org/voltdb/exportclient/FirehoseExportException.java
@@ -1,0 +1,65 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.voltdb.exportclient;
+
+import java.util.Arrays;
+import java.util.IllegalFormatConversionException;
+import java.util.MissingFormatArgumentException;
+import java.util.UnknownFormatConversionException;
+
+public class FirehoseExportException extends RuntimeException {
+
+    private static final long serialVersionUID = 4260074108700559787L;
+
+    public FirehoseExportException() {
+    }
+
+    public FirehoseExportException(String format, Object...args) {
+        super(format(format, args));
+    }
+
+    public FirehoseExportException(Throwable cause) {
+        super(cause);
+    }
+
+    public FirehoseExportException(String format, Throwable cause, Object...args) {
+        super(format(format, args), cause);
+    }
+
+    static protected String format(String format, Object...args) {
+        String formatted = null;
+        try {
+            formatted = String.format(format, args);
+        } catch (MissingFormatArgumentException|IllegalFormatConversionException|
+                UnknownFormatConversionException ignoreThem) {
+        }
+        finally {
+            if (formatted == null) {
+                formatted = "Format: " + format + ", arguments: " + Arrays.toString(args);
+            }
+        }
+        return formatted;
+    }
+}

--- a/src/main/java/org/voltdb/exportclient/FirehoseExportLogger.java
+++ b/src/main/java/org/voltdb/exportclient/FirehoseExportLogger.java
@@ -1,0 +1,114 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.voltdb.exportclient;
+
+import java.util.concurrent.TimeUnit;
+
+import org.voltcore.logging.Level;
+import org.voltcore.logging.VoltLogger;
+import org.voltcore.utils.EstTime;
+import org.voltcore.utils.RateLimitedLogger;
+
+public class FirehoseExportLogger {
+
+    final static long SUPPRESS_INTERVAL = 10;
+    final private VoltLogger m_logger = new VoltLogger("ExportClient");
+
+    public FirehoseExportLogger() {
+    }
+
+    private void log(Level level, Throwable cause, String format, Object...args) {
+        RateLimitedLogger.tryLogForMessage(
+                EstTime.currentTimeMillis(),
+                SUPPRESS_INTERVAL, TimeUnit.SECONDS,
+                m_logger, level,
+                cause, format, args
+                );
+    }
+
+    public VoltLogger getLogger() {
+        return m_logger;
+    }
+
+    public void trace(String format, Object...args) {
+        if (m_logger.isTraceEnabled()) {
+            log(Level.TRACE, null, format, args);
+        }
+    }
+
+    public void debug(String format, Object...args) {
+        if (m_logger.isDebugEnabled()) {
+            log(Level.DEBUG, null, format, args);
+        }
+    }
+
+    public void info(String format, Object...args) {
+        if (m_logger.isInfoEnabled()) {
+            log(Level.INFO, null, format, args);
+        }
+    }
+
+    public void warn(String format, Object...args) {
+        log(Level.WARN, null, format, args);
+    }
+
+    public void error(String format, Object...args) {
+        log(Level.ERROR, null, format, args);
+    }
+
+    public void fatal(String format, Object...args) {
+        log(Level.FATAL, null, format, args);
+    }
+
+    public void trace(String format, Throwable cause, Object...args) {
+        if (m_logger.isTraceEnabled()) {
+            log(Level.TRACE, cause, format, args);
+        }
+    }
+
+    public void debug(String format, Throwable cause, Object...args) {
+        if (m_logger.isDebugEnabled()) {
+            log(Level.DEBUG, cause, format, args);
+        }
+    }
+
+    public void info(String format, Throwable cause, Object...args) {
+        if (m_logger.isInfoEnabled()) {
+            log(Level.INFO, cause, format, args);
+        }
+    }
+
+    public void warn(String format, Throwable cause, Object...args) {
+        log(Level.WARN, cause, format, args);
+    }
+
+    public void error(String format, Throwable cause, Object...args) {
+        log(Level.ERROR, cause, format, args);
+    }
+
+    public void fatal(String format, Throwable cause, Object...args) {
+        log(Level.FATAL, cause, format, args);
+    }
+}

--- a/src/main/java/org/voltdb/exportclient/FirehoseSink.java
+++ b/src/main/java/org/voltdb/exportclient/FirehoseSink.java
@@ -48,9 +48,9 @@ public class FirehoseSink {
 
     private final List<ListeningExecutorService> m_executors;
 
-    private String m_streamName;
+    private final String m_streamName;
     private AmazonKinesisFirehoseClient m_client;
-    private int m_concurrentWriters;
+    private final int m_concurrentWriters;
     private final AtomicInteger m_backpressureIndication = new AtomicInteger(0);
     private BackOff m_backOff;
 

--- a/src/main/java/org/voltdb/exportclient/FirehoseSink.java
+++ b/src/main/java/org/voltdb/exportclient/FirehoseSink.java
@@ -1,0 +1,136 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (C) 2008-2016 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.voltdb.exportclient;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.voltcore.utils.CoreUtils;
+
+import com.amazonaws.services.kinesisfirehose.AmazonKinesisFirehoseClient;
+import com.amazonaws.services.kinesisfirehose.model.PutRecordBatchRequest;
+import com.amazonaws.services.kinesisfirehose.model.PutRecordBatchResult;
+import com.amazonaws.services.kinesisfirehose.model.Record;
+import com.google_voltpatches.common.collect.ImmutableList;
+import com.google_voltpatches.common.util.concurrent.Futures;
+import com.google_voltpatches.common.util.concurrent.ListenableFuture;
+import com.google_voltpatches.common.util.concurrent.ListeningExecutorService;
+
+public class FirehoseSink {
+    private final static FirehoseExportLogger LOG = new FirehoseExportLogger();
+
+    private final List<ListeningExecutorService> m_executors;
+
+    private String m_streamName;
+    private AmazonKinesisFirehoseClient m_client;
+    private int m_concurrentWriters;
+    private final AtomicInteger m_backpressureIndication = new AtomicInteger(0);
+    private BackOff m_backOff;
+
+    public FirehoseSink(String streamName, AmazonKinesisFirehoseClient client, int concurrentWriters, BackOff backOff) {
+        ImmutableList.Builder<ListeningExecutorService> lbldr = ImmutableList.builder();
+        for (int i = 0; i < concurrentWriters; ++i) {
+            String threadName = "Firehose Deliver Stream " + streamName + " Sink Writer " + i;
+            lbldr.add(CoreUtils.getListeningSingleThreadExecutor(threadName, CoreUtils.MEDIUM_STACK_SIZE));
+        }
+        m_executors = lbldr.build();
+        m_streamName = streamName;
+        m_client = client;
+        m_concurrentWriters = concurrentWriters;
+        m_backOff = backOff;
+    }
+
+    ListenableFuture<?> asWriteTask(List<Record> recordsList) {
+        final int hashed = ThreadLocalRandom.current().nextInt(m_concurrentWriters);
+        if (m_executors.get(hashed).isShutdown()) {
+            return Futures.immediateFailedFuture(new FirehoseExportException("hive sink executor is shut down"));
+        }
+        return m_executors.get(hashed).submit(new Callable<Void>() {
+            @Override
+            public Void call() throws Exception {
+                PutRecordBatchRequest batchRequest = new PutRecordBatchRequest().withDeliveryStreamName(m_streamName)
+                        .withRecords(recordsList);
+                applyBackPressure();
+                PutRecordBatchResult res = m_client.putRecordBatch(batchRequest);
+                if (res.getFailedPutCount() > 0) {
+                    setBackPressure(true);
+                    String msg = "%d Firehose records failed";
+                    LOG.warn(msg, res.getFailedPutCount());
+                    throw new FirehoseExportException(msg, res.getFailedPutCount());
+                }
+                setBackPressure(false);
+                return null;
+            }
+        });
+    }
+
+    public void write(Queue<List<Record>> records) {
+        List<ListenableFuture<?>> tasks = new ArrayList<>();
+        for (List<Record> recordsList : records) {
+            tasks.add(asWriteTask(recordsList));
+        }
+        try {
+            Futures.allAsList(tasks).get();
+        } catch (InterruptedException e) {
+            String msg = "Interrupted write for message %s";
+            LOG.error(msg, e, records);
+            throw new FirehoseExportException(msg, e, records);
+        } catch (ExecutionException e) {
+            if (e.getCause() instanceof FirehoseExportException) {
+                throw (FirehoseExportException) e.getCause();
+            }
+            String msg = "Fault on write for message %s";
+            LOG.error(msg, e, records);
+            throw new FirehoseExportException(msg, e, records);
+        }
+    }
+
+    private boolean setBackPressure(boolean b) {
+        int prev = m_backpressureIndication.get();
+        int delta = b ? 1 : -(prev > 1 ? prev >> 1 : 1);
+        int next = prev + delta;
+        while (next >= 0 && !m_backpressureIndication.compareAndSet(prev, next)) {
+            prev = m_backpressureIndication.get();
+            delta = b ? 1 : -(prev > 1 ? prev >> 1 : 1);
+            next = prev + delta;
+        }
+        return b;
+    }
+
+    private void applyBackPressure() {
+        int sleep = m_backOff.backoff(m_backpressureIndication.get());
+        LOG.warn("Sleep for back pressure for %d ms", sleep);
+        try {
+            Thread.sleep(sleep);
+        } catch (InterruptedException e) {
+            LOG.debug("Sleep for back pressure interrupted", e);
+        }
+    }
+}

--- a/src/main/java/org/voltdb/exportclient/KinesisFirehoseExportClient.java
+++ b/src/main/java/org/voltdb/exportclient/KinesisFirehoseExportClient.java
@@ -31,6 +31,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
 import java.util.Queue;
+import java.util.Random;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
@@ -122,6 +123,7 @@ public class KinesisFirehoseExportClient extends ExportClientBase {
         // based on the limit
         // for small records (row length < 1KB): records/s is the bottleneck
         // for large records (row length > 1KB): data throughput is the bottleneck
+
         private int lowWaterMark = 50; // tuned base on orignal limit + small record workload        ;
         private int highWaterMark = 150;
         final private int maxSleepTime = 1000;
@@ -153,6 +155,8 @@ public class KinesisFirehoseExportClient extends ExportClientBase {
                     + " generation " + source.m_generation, CoreUtils.MEDIUM_STACK_SIZE);
             m_decoder = builder.build();
             allowBackPressure = true;
+            Random random = new Random();
+            highWaterMark += random.nextInt(50); // primed each export step each other
         }
 
         private void validateStream() throws RestartBlockException, InterruptedException {

--- a/src/main/java/org/voltdb/exportclient/KinesisFirehoseExportClient.java
+++ b/src/main/java/org/voltdb/exportclient/KinesisFirehoseExportClient.java
@@ -55,7 +55,7 @@ import com.google_voltpatches.common.base.Throwables;
 import com.google_voltpatches.common.util.concurrent.ListeningExecutorService;
 
 public class KinesisFirehoseExportClient extends ExportClientBase {
-    private static final ExportClientLogger LOG = new ExportClientLogger();
+    private static final FirehoseExportLogger LOG = new FirehoseExportLogger();
 
     private Region m_region;
     private String m_streamName;
@@ -80,7 +80,7 @@ public class KinesisFirehoseExportClient extends ExportClientBase {
     public static final String BACKOFF_CAP = "backoff.cap";
     public static final String STREAM_LIMIT = "stream.limit";
     public static final String BACKOFF_TYPE = "backoff.type";
-    public static final String CONCURRENT_WRITER = "concurrent.writer";
+    public static final String CONCURRENT_WRITER = "concurrent.writers";
 
     public static final int BATCH_NUMBER_LIMIT = 500;
     public static final int BATCH_SIZE_LIMIT = 4*1024*1024;
@@ -127,7 +127,7 @@ public class KinesisFirehoseExportClient extends ExportClientBase {
 
         // concurrent aws client = number of export table to this stream * number of voltdb partition
         m_concurrentWriter = Integer.parseInt(config.getProperty(CONCURRENT_WRITER,"8"));
-        m_backOffStrategy = config.getProperty(BACKOFF_TYPE,"decor");
+        m_backOffStrategy = config.getProperty(BACKOFF_TYPE,"full");
 
         m_firehoseClient = new AmazonKinesisFirehoseClient(
                 new BasicAWSCredentials(m_accessKey, m_secretKey));

--- a/src/main/java/org/voltdb/exportclient/KinesisFirehoseExportClient.java
+++ b/src/main/java/org/voltdb/exportclient/KinesisFirehoseExportClient.java
@@ -32,9 +32,7 @@ import java.util.List;
 import java.util.Properties;
 import java.util.Queue;
 import java.util.TimeZone;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.voltcore.utils.CoreUtils;
 import org.voltdb.VoltDB;
@@ -50,9 +48,6 @@ import com.amazonaws.services.kinesisfirehose.AmazonKinesisFirehoseClient;
 import com.amazonaws.services.kinesisfirehose.model.DescribeDeliveryStreamRequest;
 import com.amazonaws.services.kinesisfirehose.model.DescribeDeliveryStreamResult;
 import com.amazonaws.services.kinesisfirehose.model.InvalidArgumentException;
-import com.amazonaws.services.kinesisfirehose.model.PutRecordBatchRequest;
-import com.amazonaws.services.kinesisfirehose.model.PutRecordBatchResponseEntry;
-import com.amazonaws.services.kinesisfirehose.model.PutRecordBatchResult;
 import com.amazonaws.services.kinesisfirehose.model.Record;
 import com.amazonaws.services.kinesisfirehose.model.ResourceNotFoundException;
 import com.amazonaws.services.kinesisfirehose.model.ServiceUnavailableException;
@@ -67,28 +62,28 @@ public class KinesisFirehoseExportClient extends ExportClientBase {
     private String m_accessKey;
     private String m_secretKey;
     private TimeZone m_timeZone;
+    private AmazonKinesisFirehoseClient m_firehoseClient;
+    private FirehoseSink m_sink;
     private String m_recordSeparator;
+
+
     private int m_backOffCap;
     private int m_backOffBase;
-    private int m_backOffConcurrentClient;
+    private int m_streamLimit;
+    private int m_concurrentWriter;
     private String m_backOffStrategy;
-    private final AtomicInteger m_backpressureIndication = new AtomicInteger(0);
-    private final AtomicInteger m_FailuerCount = new AtomicInteger(0);
-    private final AtomicInteger m_SuccessCount = new AtomicInteger(0);
-    private boolean m_backOffAlwaysRestartBlock;
-    private boolean m_backOffAllow;
-
-
+    private BackOff m_backOff;
 
     public static final String ROW_LENGTH_LIMIT = "row.length.limit";
     public static final String RECORD_SEPARATOR = "record.separator";
-    public static final String BACKOFF_CAP = "backoff.cap";
-    public static final String BACKOFF_BASE = "backoff.base";
-    public static final String BACKOFF_STRATEGY = "backoff.strategy";
-    public static final String BACKOFF_CONCURRENT_CLIENT = "backoff.concurrent.client";
 
-    public static final String BACKOFF_ALLOW = "backoff.allow";
-    public static final String BACKOFF_ALWAYS_RESTARTBLOCK = "backoff.always.restartblock";
+    public static final String BACKOFF_CAP = "backoff.cap";
+    public static final String STREAM_LIMIT = "stream.limit";
+    public static final String BACKOFF_TYPE = "backoff.type";
+    public static final String CONCURRENT_WRITER = "concurrent.writer";
+
+    public static final int BATCH_NUMBER_LIMIT = 500;
+    public static final int BATCH_SIZE_LIMIT = 4*1024*1024;
 
     @Override
     public void configure(Properties config) throws Exception
@@ -123,17 +118,22 @@ public class KinesisFirehoseExportClient extends ExportClientBase {
 
         m_backOffCap = Integer.parseInt(config.getProperty(BACKOFF_CAP,"1000"));
         // minimal interval between each putRecordsBatch api call;
+        // for small records (row length < 1KB): records/s is the bottleneck
+        // for large records (row length > 1KB): data throughput is the bottleneck
         // for orignal limit, (5000 records/s  divie by 500 records per call = 10 calls)
         // interval is 1000 ms / 10 = 100 ms
-        m_backOffBase = Integer.parseInt(config.getProperty(BACKOFF_BASE,"100"));
+        m_streamLimit = Integer.parseInt(config.getProperty(STREAM_LIMIT,"5000"));
+        m_backOffBase = Math.max(2, 1000 / (m_streamLimit/BATCH_NUMBER_LIMIT));
 
         // concurrent aws client = number of export table to this stream * number of voltdb partition
-        m_backOffConcurrentClient = Integer.parseInt(config.getProperty(BACKOFF_CONCURRENT_CLIENT,"8"));
-        m_backOffStrategy = config.getProperty(BACKOFF_STRATEGY,"decor");
+        m_concurrentWriter = Integer.parseInt(config.getProperty(CONCURRENT_WRITER,"8"));
+        m_backOffStrategy = config.getProperty(BACKOFF_TYPE,"decor");
 
-
-        m_backOffAllow = Boolean.parseBoolean(config.getProperty(BACKOFF_ALLOW,"true"));
-        m_backOffAlwaysRestartBlock = Boolean.parseBoolean(config.getProperty(BACKOFF_ALWAYS_RESTARTBLOCK,"true"));
+        m_firehoseClient = new AmazonKinesisFirehoseClient(
+                new BasicAWSCredentials(m_accessKey, m_secretKey));
+        m_firehoseClient.setRegion(m_region);
+        m_backOff = BackOffFactory.getBackOff(m_backOffStrategy, m_backOffBase, m_backOffCap);
+        m_sink = new FirehoseSink(m_streamName,m_firehoseClient, m_concurrentWriter, m_backOff);
     }
 
     @Override
@@ -150,21 +150,6 @@ public class KinesisFirehoseExportClient extends ExportClientBase {
         private Queue<List<Record>> m_records;
         private List<Record> currentBatch;
         private int m_currentBatchSize;
-        private AmazonKinesisFirehoseClient m_firehoseClient;
-
-        // minimal interval between each putRecordsBatch api call;
-        // based on the limit
-        // for small records (row length < 1KB): records/s is the bottleneck
-        // for large records (row length > 1KB): data throughput is the bottleneck
-        /*
-        private int lowWaterMark = 50; // tuned base on orignal limit + small record workload        ;
-        private int highWaterMark = 150;
-        final private int maxSleepTime = 1000;
-        final private int incInterval = 100;
-        final private int decInterval = 10;
-         */
-        public static final int BATCH_NUMBER_LIMIT = 500;
-        public static final int BATCH_SIZE_LIMIT = 4*1024*1024;
 
         @Override
         public ListeningExecutorService getExecutor() {
@@ -211,9 +196,6 @@ public class KinesisFirehoseExportClient extends ExportClientBase {
 
         final void checkOnFirstRow() throws RestartBlockException {
             if (!m_primed) try {
-                m_firehoseClient = new AmazonKinesisFirehoseClient(
-                        new BasicAWSCredentials(m_accessKey, m_secretKey));
-                m_firehoseClient.setRegion(m_region);
                 validateStream();
             } catch (AmazonServiceException | InterruptedException e) {
                 LOG.error("Unable to instantiate a Amazon Kinesis Firehose client", e);
@@ -236,7 +218,7 @@ public class KinesisFirehoseExportClient extends ExportClientBase {
             }
             // PutRecordBatchRequest can not contain more than 500 records
             // And up to a limit of 4 MB for the entire request
-            if (((m_currentBatchSize + rowSize) > BATCH_SIZE_LIMIT) || (currentBatch.size() >= (BATCH_NUMBER_LIMIT/m_backOffConcurrentClient))) {
+            if (((m_currentBatchSize + rowSize) > BATCH_SIZE_LIMIT) || (currentBatch.size() >= (BATCH_NUMBER_LIMIT/m_concurrentWriter))) {
                 // roll to next batch
                 m_records.add(currentBatch);
                 m_currentBatchSize = 0;
@@ -277,148 +259,15 @@ public class KinesisFirehoseExportClient extends ExportClientBase {
                 m_currentBatchSize = 0;
                 currentBatch = new LinkedList<Record>();
             }
+
             try {
-                List<Record> recordsList;
-                BackOff backOff;
-                switch (m_backOffStrategy) {
-                    case "full":
-                        backOff = new ExpoBackOffFullJitter(m_backOffBase, m_backOffCap);
-                        break;
-                    case "equal":
-                        backOff = new ExpoBackOffEqualJitter(m_backOffBase, m_backOffCap);
-                        break;
-                    default:
-                        backOff = new ExpoBackOffDecor(m_backOffBase, m_backOffCap);
-                        break;
-                }
-
-                while (!m_records.isEmpty()) {
-                    recordsList = m_records.poll();
-                    PutRecordBatchRequest batchRequest = new PutRecordBatchRequest().withDeliveryStreamName(
-                            m_streamName).withRecords(recordsList);
-                    int trial = 3;
-                    boolean retry = true;
-                    while (trial > 0 && retry) {
-                        applyBackPressure(m_backOffAllow, backOff);
-                        PutRecordBatchResult res = m_firehoseClient.putRecordBatch(batchRequest);
-                        if (res.getFailedPutCount() > 0) {
-                            int i = 0;
-                            for (PutRecordBatchResponseEntry entry : res.getRequestResponses()) {
-                                if (entry.getErrorMessage() != null) {
-                                    LOG.warn("Record failed with response: %s, Error Code: %s. ", entry.getErrorMessage(), entry.getErrorCode());
-                                    LOG.debug("Record failed : %d, Success: %d. ", m_FailuerCount.incrementAndGet(), m_SuccessCount.get() );
-                                    if (!entry.getErrorCode().equals("ServiceUnavailableException") || m_backOffAlwaysRestartBlock) {
-                                        throw new RestartBlockException(true);
-                                    }
-                                    i++;
-                                } else {
-                                    recordsList.remove(i);
-                                    m_SuccessCount.incrementAndGet();
-                                }
-                            }
-                            setBackPressure(true);
-                            batchRequest = new PutRecordBatchRequest().withDeliveryStreamName(
-                                    m_streamName).withRecords(recordsList);
-                        } else {
-                            retry = false;
-                            setBackPressure(false);
-                            m_SuccessCount.addAndGet(recordsList.size());
-                        }
-                        trial--;
-                    }
-
-                    if (trial == 0 && retry) {
-                        throw new RestartBlockException(true);
-                    }
-                }
+                m_sink.write(m_records);
+            } catch (FirehoseExportException e) {
+                throw new RestartBlockException("firehose write fault", e, true);
             } catch (ResourceNotFoundException | InvalidArgumentException | ServiceUnavailableException e) {
                 LOG.error("Failed to send record batch", e);
                 throw new RestartBlockException("Failed to send record batch", e, true);
             }
-            LOG.debug("Record failed : %d, Success: %d. ", m_FailuerCount.incrementAndGet(), m_SuccessCount.get());
-        }
-
-        private boolean setBackPressure(boolean b) {
-            int prev = m_backpressureIndication.get();
-            int delta = b ? 1 : -(prev > 1 ? prev >> 1 : 1);
-            int next = prev + delta;
-            while (next >= 0 && (1 << next <= m_backOffCap) && !m_backpressureIndication.compareAndSet(prev, next)) {
-                prev = m_backpressureIndication.get();
-                delta = b ? 1 : -(prev > 1 ? prev >> 1 : 1);
-                next = prev + delta;
-            }
-            return b;
-        }
-
-        private void applyBackPressure(final boolean allowBackPressure, BackOff backOff) {
-            if (!allowBackPressure) {
-                return;
-            }
-            int sleep = backOff.backoff(m_backpressureIndication.get());
-            LOG.warn("Sleep for back pressure for %d ms", sleep);
-            try {
-                Thread.sleep(sleep);
-            } catch (InterruptedException e) {
-                LOG.debug("Sleep for back pressure interrupted", e);
-            }
-        }
-    }
-
-    abstract class BackOff {
-        int base;
-        int cap;
-
-        public BackOff(int base, int cap) {
-            this.base = base;
-            this.cap = cap;
-        }
-
-        public int expo(int n) {
-            return Math.min(cap, base * (1<<n));
-        }
-
-        abstract public int backoff(int n);
-    }
-
-    class ExpoBackOffFullJitter extends BackOff {
-
-        public ExpoBackOffFullJitter(int base, int cap) {
-            super(base, cap);
-        }
-
-        @Override
-        public int backoff(int n) {
-            return ThreadLocalRandom.current().nextInt(expo(n));
-        }
-    }
-
-    class ExpoBackOffEqualJitter extends BackOff {
-
-        public ExpoBackOffEqualJitter(int base, int cap) {
-            super(base, cap);
-        }
-
-        @Override
-        public int backoff(int n) {
-            int v = expo(n) / 2 ;
-            return ThreadLocalRandom.current().nextInt(v, 3 * v);
-        }
-    }
-
-    class ExpoBackOffDecor extends BackOff {
-        int sleep;
-        public ExpoBackOffDecor(int base, int cap) {
-            super(base, cap);
-            sleep = base;
-        }
-
-        @Override
-        public int backoff(int n) {
-            if (n == 0) {
-                sleep = base;
-            }
-            sleep = Math.min(cap, ThreadLocalRandom.current().nextInt(base, sleep * 3));
-            return sleep;
         }
     }
 }


### PR DESCRIPTION
tunable parameters:

backoff.cap : default 1000 ms

stream.limit: firehose stream limit, default 5000 records/s

backoff.type: default decor ( implement based on https://www.awsarchitectureblog.com/2015/03/backoff.html)

concurrent.writer: concurrent firehose client call putReocrdBatch API 
